### PR TITLE
ci: run commitlint as dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,28 @@ on:
   pull_request:
 
 jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+
+      - name: Lint commits
+        run: npx commitlint --from=HEAD~1 --to=HEAD
+
   test:
     runs-on: ubuntu-latest
+    needs: commitlint
     env:
       CI: true
       HEADLESS: true
@@ -35,9 +55,6 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci --prefix frontend
-
-      - name: Lint commits
-        run: npx --prefix frontend commitlint --from=HEAD~1 --to=HEAD
 
       - name: Run tests
         run: bash scripts/run_ci_tests.sh


### PR DESCRIPTION
## Summary
- add dedicated commitlint job to CI workflow
- enforce conventional commit message format before running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b64683488329a00336d300ae0af6