### PR TITLE
fix(scraper): simplify webdriver setup

### DIFF
--- a/scraper/core/browser.py
+++ b/scraper/core/browser.py
@@ -1,19 +1,13 @@
 import logging
-import platform
-import subprocess
+import os
 import random
 from typing import Optional
 from urllib.parse import urlparse
 
 from selenium import webdriver
-from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.common.exceptions import WebDriverException, SessionNotCreatedException
-
-from webdriver_manager.chrome import ChromeDriverManager
-from webdriver_manager.firefox import GeckoDriverManager
+from selenium.common.exceptions import WebDriverException
 
 from scraper.core.config.config import PROXIES
 from scraper.core.constants import (
@@ -24,20 +18,8 @@ from scraper.core.constants import (
     DEFAULT_HEIGHT,
 )
 
-# 🔇 Wyciszenie komunikatów webdriver-managera
-logging.getLogger("WDM").setLevel(logging.CRITICAL)
-
 # 🧠 Używamy jednego loggera globalnego
 logger = logging.getLogger(__name__)
-
-FALLBACK_CHROME_DRIVER_VERSIONS = [
-    "135.0.7049.96", "135.0.5435.2", "135.0.5432.10",
-    "134.0.5376.126", "134.0.5376.39", "133.0.5304.19",
-    "132.0.5230.25", "122.0.6261.94", "121.0.6167.85",
-    "120.0.6099.109", "119.0.6045.105", "118.0.5993.70",
-    "117.0.5938.92", "116.0.5845.96", "115.0.5790.102", "114.0.5735.90"
-]
-
 
 def get_random_proxy() -> Optional[str]:
     """Return a random proxy from configuration if available."""
@@ -46,37 +28,6 @@ def get_random_proxy() -> Optional[str]:
         logger.info(f"Using proxy: {proxy}")
         return proxy
     return None
-
-def get_chrome_version():
-    try:
-        system = platform.system()
-        if system == "Darwin":
-            process = subprocess.run(
-                ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", "--version"],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            version = process.stdout.strip().split("Google Chrome ")[1].split()[0]
-        elif system == "Windows":
-            process = subprocess.run(
-                ["reg", "query", "HKEY_CURRENT_USER\\Software\\Google\\Chrome\\BLBeacon", "/v", "version"],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            version = process.stdout.strip().split()[-1]
-        elif system == "Linux":
-            process = subprocess.run(
-                ["google-chrome", "--version"],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            version = process.stdout.strip().split("Google Chrome ")[1].split()[0]
-        else:
-            return None
-
-        logger.info(f"Detected full Chrome version: {version}")
-        return version
-    except Exception as e:
-        logger.warning(f"Failed to get Chrome version: {e}")
-        return None
-
 
 def setup_browser(headless=False, specific_version=None, use_firefox_fallback=True):
     try:
@@ -121,48 +72,21 @@ def setup_chrome_browser(headless=False, specific_version=None):
     if headless:
         options.add_argument("--headless=new")
 
-    chrome_version = get_chrome_version()
-    version_fallbacks = [specific_version] if specific_version else []
-
-    if chrome_version:
-        version_parts = chrome_version.split('.')
-        major_version = version_parts[0]
-        version_fallbacks += [
-            chrome_version,
-            f"{major_version}.0.{version_parts[2] if len(version_parts) > 2 else '0'}.{version_parts[3] if len(version_parts) > 3 else '0'}",
-            f"{major_version}.0.0.0"
-        ]
-
-        for fallback in FALLBACK_CHROME_DRIVER_VERSIONS:
-            if fallback not in version_fallbacks:
-                version_fallbacks.append(fallback)
-    else:
-        version_fallbacks = FALLBACK_CHROME_DRIVER_VERSIONS
-
-    for version in version_fallbacks:
-        try:
-            logger.debug(f"Trying ChromeDriver version: {version}")
-            driver = webdriver.Chrome(
-                service=ChromeService(ChromeDriverManager(version=version).install()),
-                options=options
-            )
-            driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {
-                "source": "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"
-            })
-            logger.info(f"✓ SUCCESS: Initialized ChromeDriver {version}")
-            return driver
-        except Exception as e:
-            logger.warning(f"❌ ChromeDriver {version} failed: {e}")
-            continue
+    chrome_bin = os.getenv("CHROME_BIN")
+    if chrome_bin:
+        options.binary_location = chrome_bin
 
     try:
-        logger.info("Trying system ChromeDriver")
         driver = webdriver.Chrome(options=options)
+        driver.execute_cdp_cmd(
+            "Page.addScriptToEvaluateOnNewDocument",
+            {"source": "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"},
+        )
+        logger.info("Successfully initialized Chrome WebDriver")
         return driver
     except Exception as e:
-        logger.warning(f"System ChromeDriver failed: {e}")
-
-    raise WebDriverException("All ChromeDriver attempts failed")
+        logger.error(f"Failed to initialize Chrome WebDriver: {e}")
+        raise WebDriverException(f"Chrome WebDriver initialization failed: {e}")
 
 
 def setup_firefox_browser(headless=False):
@@ -197,10 +121,7 @@ def setup_firefox_browser(headless=False):
             options.set_preference("network.proxy.no_proxies_on", "")
 
     try:
-        driver = webdriver.Firefox(
-            service=FirefoxService(GeckoDriverManager().install()),
-            options=options
-        )
+        driver = webdriver.Firefox(options=options)
         # Align behavior with Chrome by hiding webdriver attribute
         driver.execute_script(
             "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"


### PR DESCRIPTION
## Summary
- initialize Chrome and Firefox WebDrivers directly without webdriver-manager
- honor `CHROME_BIN` and headless options during driver setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a100a1acd48329996068f06323ed09