### PR TITLE
docs: update backend port references

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Argumenty CLI:
 ```bash
 export SECRET_KEY=devsecret
 export ADMIN_PASSWORD_HASH=<bcrypt_hash>
-PORT=61973 uvicorn backend.main:app --reload --port $PORT
+PORT=38273 uvicorn backend.main:app --reload --port $PORT
 ```
 
-Otwórz `http://localhost:61973` – pojawi się panel z listą ofert i trendem cenowym.
+Otwórz `http://localhost:38273` – pojawi się panel z listą ofert i trendem cenowym.
 *Jeśli w bazie brak danych, najpierw uruchom scraper.*
 
 **Statyczne zasoby:** Pliki CSS/JS w szablonach (Bootstrap, Chart.js, Leaflet) są pobierane z CDN z atrybutami `integrity` i `crossorigin`. Jeśli wolisz trzymać je lokalnie (np. do pracy offline), umieść je w katalogu `backend/static/` i zaktualizuj odwołania w szablonach.
@@ -130,7 +130,7 @@ Serwisy:
 
 | Kontener   | Funkcja                                          |
 |------------|--------------------------------------------------|
-| `backend`  | FastAPI na porcie `61973` (zmienne `PORT`)       |
+| `backend`  | FastAPI na porcie `38273` (zmienne `PORT`)       |
 | `scraper`  | Celery worker pobierający zadania                |
 | `db`       | PostgreSQL                                      |
 | `redis`    | broker wiadomości                                |
@@ -213,7 +213,7 @@ Zależnie od konfiguracji, raport zapisywany jest jako `summary.txt` albo dopisy
 2. Stwórz i aktywuj wirtualne środowisko, zainstaluj `pip install -r requirements.txt`.
 3. Ustaw w `.env` zmienne (`SECRET_KEY`, `ADMIN_PASSWORD_HASH`, `DB_URL` wskazujący na SQLite lub PostgreSQL).
 4. Uruchom `uvicorn` w tle (np. `scripts/restart_uvicorn.sh` + cron `@reboot`).
-5. W panelu MyDevil ustaw **reverse proxy** do portu backendu (`http://localhost:61973` → subdomena).
+5. W panelu MyDevil ustaw **reverse proxy** do portu backendu (`http://localhost:38273` → subdomena).
 
 ### Frontend (React)
 
@@ -257,7 +257,7 @@ Zależnie od konfiguracji, raport zapisywany jest jako `summary.txt` albo dopisy
 
 1. **Świeży QA** klonuje repo.
 2. Wykonuje kroki z sekcji 3 (instalacja zależności, `playwright install`, uruchomienie scrapera).
-3. Uruchamia backend (`uvicorn`) i otwiera `http://localhost:61973`.
+3. Uruchamia backend (`uvicorn`) i otwiera `http://localhost:38273`.
 4. Widzi w UI listę produktów, tabelę ofert oraz – jeśli nie wyłączył – wykres trendu.
 
 Po przejściu powyższych kroków cały system działa lokalnie z realnymi danymi.
@@ -286,8 +286,8 @@ uvicorn backend.main:app --host 127.0.0.1 --port $BACKEND_PORT --workers 4 &
 cd frontend && NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL npm run build
 ```
 
-Uwaga: `smart.bodora.pl` i `backend.bodora.pl` są proxy i nie wymagają dodatkowej konfiguracji
-aplikacji — proxy po prostu przekierowuje ruch do `localhost:PORT` na hoście.
+Uwaga: `smart.bodora.pl` (→ `localhost:61973`) i `backend.bodora.pl` (→ `localhost:38273`) są proxy i nie
+wymagają dodatkowej konfiguracji aplikacji — proxy po prostu przekierowuje ruch do odpowiedniego portu na hoście.
 
 ## 12. Testy
 


### PR DESCRIPTION
## Summary
- switch backend instructions to port 38273
- clarify proxy domain port mappings

## Testing
- `pytest -q` *(fails: npx tsx command returned non-zero exit status)*

------
https://chatgpt.com/codex/tasks/task_e_68a129c1f5d883299161fb05ec0bfcc3