### PR TITLE
docs(loadtests): update host port and note production proxy

### DIFF
--- a/loadtests/README.md
+++ b/loadtests/README.md
@@ -6,7 +6,7 @@ This directory contains a basic [Locust](https://locust.io/) scenario that exerc
 ## Running
 
 ```
-locust -f loadtests/locustfile.py --headless -u 10 -r 10 -t 10s --host http://localhost:8000
+locust -f loadtests/locustfile.py --headless -u 10 -r 10 -t 10s --host http://localhost:38273  # backend.bodora.pl proxies to the same port in production
 ```
 
 Adjust the host to point at a running instance of the application.


### PR DESCRIPTION
## Summary
- update Locust host port to 38273
- note production proxy at backend.bodora.pl

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError: Command '['npx', '--yes', 'tsx', '-e', "import React from 'react';import ReactDOMServer from 'react-dom/server';import App from './src/App.tsx';const offers=[{price:10,price_bucket:'super_okazja',is_historical_low:true},{price:25,price_bucket:'okazja',is_historical_low:false},{price:40,price_bucket:'normalna',is_historical_low:false}];console.log(ReactDOMServer.renderToString(React.createElement(App,{offers})));"]' returned non-zero exit status 1.)`

------
https://chatgpt.com/codex/tasks/task_e_68a19195d6008329bb8fd7ae3ae105c9