### PR TITLE
chore(infra): expose backend and frontend ports

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,8 +18,9 @@ RUN pip install --no-cache /wheels/* && rm -rf /wheels
 COPY backend ./backend
 COPY scraper ./scraper
 
-EXPOSE 61973
+# Expose backend through reverse proxy (backend.bodora.pl)
+EXPOSE 38273
 
-ENV PORT=61973
+ENV PORT=38273
 
 CMD ["sh", "-c", "uvicorn backend.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,9 +54,9 @@ else:
     # These proxy domains (smart.bodora.pl and backend.bodora.pl) route to localhost:PORT on the host.
     allow_origins = [
         "http://localhost:3000",
-        "http://localhost:8000",
-        "https://smart.bodora.pl",
-        "https://backend.bodora.pl",
+        "http://localhost:38273",
+        "https://smart.bodora.pl",  # → localhost:61973
+        "https://backend.bodora.pl",  # → localhost:38273
     ]
 
 # By default do not allow credentials unless explicitly enabled in env for trusted deployments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,16 @@ services:
     depends_on:
       - redis
     ports:
-      - "8000:8000"
+      - "38273:38273" # backend.bodora.pl → localhost:38273
+  frontend:
+    build:
+      context: ./frontend
+    env_file:
+      - .env
+    depends_on:
+      - backend
+    ports:
+      - "61973:61973" # smart.bodora.pl → localhost:61973
   scraper:
     build:
       context: ./scraper


### PR DESCRIPTION
## Summary
- update backend service to run on 38273
- add frontend service on 61973
- document proxy domains for backend and frontend

## Testing
- `pytest -q` *(fails: CalledProcessError in frontend UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a639bb84832992aa3a97e0391cc7