### PR TITLE
fix(scripts): use backend port 38273

### DIFF
--- a/scripts/restart_uvicorn.sh
+++ b/scripts/restart_uvicorn.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PORT=61973
+PORT=38273
 CMD="uvicorn backend.main:app --host 127.0.0.1 --port $PORT --reload"
 
 # Stop running Uvicorn processes


### PR DESCRIPTION
## Summary
- fix restart script to use backend port 38273
- verify helper scripts don't rely on old port

## Testing
- `pytest -q` *(fails: CalledProcessError from npx/tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b05ccc3c8329a62aaa43c59f7cf9