### PR TITLE
refactor(backend): clean up imports

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -9,7 +9,6 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import (
     AsyncConnection,
     AsyncEngine,
-    AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -2,6 +2,7 @@ import asyncio
 from logging.config import fileConfig
 
 from alembic import context
+from backend.db import get_engine
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -12,8 +13,6 @@ if config.config_file_name is not None:
         fileConfig(config.config_file_name)
     except Exception:
         pass
-
-from backend.db import get_engine
 
 
 def run_migrations_offline():

--- a/backend/migrations/versions/0002_add_indexes.py
+++ b/backend/migrations/versions/0002_add_indexes.py
@@ -1,7 +1,6 @@
 """Add performance indexes for pharmacy_prices"""
 
 from alembic import op
-import sqlalchemy as sa
 
 revision = "0002_add_indexes"
 down_revision = "0001_create_tables"

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -2,9 +2,6 @@
 import hashlib
 import logging
 import os
-import re
-from functools import wraps
-from typing import Optional
 
 from fastapi import HTTPException, Request
 from twilio.rest import Client


### PR DESCRIPTION
## Summary
- tidy backend modules by removing unused imports and grouping remaining imports at the top

## Testing
- `python -m flake8 backend --select=F401,E402`
- `pytest` *(fails: Command '['npx', '--yes', 'tsx', ...] returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1eae493348329a007153f911fa3c5