### PR TITLE
refactor(scraper): simplify product active checks

### DIFF
--- a/scraper/cli/main.py
+++ b/scraper/cli/main.py
@@ -32,8 +32,8 @@ def main() -> None:
 
     # Count products before sync
     with Session(ENGINE) as session:
-        before_active = session.execute(select(Product).where(Product.active == True)).scalars().all()
-        before_inactive = session.execute(select(Product).where(Product.active == False)).scalars().all()
+        before_active = session.execute(select(Product).where(Product.active)).scalars().all()
+        before_inactive = session.execute(select(Product).where(~Product.active)).scalars().all()
 
     # Sync products
     sync_start = time.time()
@@ -41,9 +41,9 @@ def main() -> None:
     sync_time = time.time() - sync_start
 
     with Session(ENGINE) as session:
-        active_products = session.execute(select(Product).where(Product.active == True)).scalars().all()
+        active_products = session.execute(select(Product).where(Product.active)).scalars().all()
         after_active = len(active_products)
-        after_inactive = session.execute(select(Product).where(Product.active == False)).scalars().all()
+        after_inactive = session.execute(select(Product).where(~Product.active)).scalars().all()
         after_inactive = len(after_inactive)
 
     activated = max(0, after_active - len(before_active))

--- a/scraper/services/offers.py
+++ b/scraper/services/offers.py
@@ -97,7 +97,7 @@ def scrape_offers_once(fetch_page: Callable[[str], str] = _default_fetch) -> Non
     to provide a lightweight stub instead of launching a browser.
     """
     with Session(ENGINE) as session:
-        products = session.execute(select(Product).where(Product.active == True)).scalars().all()
+        products = session.execute(select(Product).where(Product.active)).scalars().all()
 
     seen: set[str] = set()
     for product in products:


### PR DESCRIPTION
## Summary
- simplify product active comparisons in CLI and offers services

## Testing
- `pytest -q` *(fails: module 'backend.main' has no attribute 'send_confirmation_email'; tsx command returned non-zero exit)*

------
https://chatgpt.com/codex/tasks/task_e_68a211b8ffac8329bb3e6d387caeee7d