### PR TITLE
style(backend): move docstring before future import

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Database ORM models used by the application."""
+
+from __future__ import annotations
 
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- ensure backend models module docstring is first
- keep `from __future__ import annotations` directly after docstring

## Testing
- `ruff check backend/models.py`
- `pytest -q` *(fails: module 'backend.main' has no attribute 'send_confirmation_email'; subprocess CalledProcessError running npx)*

------
https://chatgpt.com/codex/tasks/task_e_68a217a88ab08329a9f6e934d336875b