### PR TITLE
chore(scraper): remove unused datetime import

### DIFF
--- a/scraper/core/bootstrap.py
+++ b/scraper/core/bootstrap.py
@@ -5,7 +5,6 @@ import sys
 import logging
 import logging.config
 from pathlib import Path
-from datetime import datetime
 
 # Determine log level from environment with fallback to ERROR
 LOG_LEVEL = getattr(


### PR DESCRIPTION
## Summary
- remove unused datetime import from scraper core bootstrap

## Testing
- `ruff check scraper/core/bootstrap.py`
- `pytest -q` *(fails: missing backend.main.send_confirmation_email and npx tsx subprocess errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a218c8b3a0832995d373aad6a30de1