### PR TITLE
refactor(scraper): remove unused DB_PATH import

### DIFF
--- a/scraper/core/main.py
+++ b/scraper/core/main.py
@@ -18,7 +18,6 @@ from scraper.core.config.urls import URLS, extract_product_id
 from scraper.core.config.selectors import PHARMACY_ITEMS_SELECTORS
 from scraper.services.db import insert_prices
 from scraper.core.bootstrap import init_logging
-from scraper.core.config.config import DB_PATH
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove unused DB_PATH import from scraper core main

## Testing
- `ruff check scraper/core/main.py`
- `pytest` *(fails: module 'backend.main' has no attribute 'send_confirmation_email'; npx tsx build issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a21b6354948329a27858ca6bcd102d