### PR TITLE
chore(scraper): remove unused Path import

### DIFF
--- a/scraper/services/geocode_pharmacies.py
+++ b/scraper/services/geocode_pharmacies.py
@@ -9,7 +9,6 @@ import sqlite3
 import requests
 import time
 from urllib.parse import quote
-from pathlib import Path
 
 from scraper.core.config.config import DB_PATH, DB_URL, API_URL
 


### PR DESCRIPTION
## Summary
- remove unused pathlib import from geocode_pharmacies service

## Testing
- `ruff check scraper/services/geocode_pharmacies.py`


------
https://chatgpt.com/codex/tasks/task_e_68a21e4a3dc0832985f9457badb088d3