### PR TITLE
refactor(backend): simplify active product filter

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -133,7 +133,7 @@ async def get_products() -> list[dict[str, str]]:
     async with session_factory() as session:
         rows = (
             await session.execute(
-                select(Product.id, Product.name).where(Product.active == True)  # noqa: E712
+                select(Product.id, Product.name).where(Product.active)
             )
         ).all()
     return [{"id": pid, "name": name} for pid, name in rows]


### PR DESCRIPTION
## Summary
- use boolean column directly when fetching active products

## Testing
- `pytest -q` *(fails: module 'backend.main' has no attribute 'send_confirmation_email'; frontend tests subprocess failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a21bddb2b483298d8c59c2135ef654