### PR TITLE
style(tests): clean up imports and semicolon usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,15 @@ import sys
 import tempfile
 from pathlib import Path
 
-import bcrypt
-import pytest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from alembic import command
 from alembic.config import Config
+import bcrypt
 from cryptography.fernet import Fernet
+import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from backend import db as backend_db
 
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault(
@@ -31,8 +33,6 @@ def migrated_db(monkeypatch):
     monkeypatch.setattr(
         "scraper.core.config.config.DB_URL", f"sqlite:///{db_file}", raising=False
     )
-
-    from backend import db as backend_db
 
     backend_db._ENGINE_CACHE.clear()
     cfg = Config("backend/alembic.ini")

--- a/tests/products/test_discovery.py
+++ b/tests/products/test_discovery.py
@@ -1,15 +1,22 @@
+import importlib
 import os
 import sys
-import importlib
 import types
+
 import pytest
+
+try:
+    from scraper.products.discovery import discover_products
+except RuntimeError:  # Playwright missing
+    discover_products = None
 
 MIN_ITEMS = int(os.getenv("MIN_ITEMS", 10))
 
 
 @pytest.mark.skipif(not os.getenv("CI"), reason="Playwright tests run only in CI")
 def test_discover_products() -> None:
-    from scraper.products.discovery import discover_products
+    if discover_products is None:
+        pytest.skip("Playwright is required for product discovery")
 
     items = discover_products()
     assert isinstance(items, list)

--- a/tests/products/test_urls.py
+++ b/tests/products/test_urls.py
@@ -1,7 +1,9 @@
+from typing import Optional
+
 import pytest
 
-from scraper.products.urls import build_regional_url
 from scraper.products.pvid import extract_pvid
+from scraper.products.urls import build_regional_url
 
 
 @pytest.mark.parametrize(
@@ -27,8 +29,6 @@ def test_build_regional_url_with_pvid() -> None:
 
 
 def test_build_regional_url_with_auto_pvid() -> None:
-    from typing import Optional
-
     class FakeLocator:
         def __init__(self, value: Optional[str]) -> None:
             self._value = value

--- a/tests/smoke/test_imports.py
+++ b/tests/smoke/test_imports.py
@@ -4,6 +4,10 @@ import sys
 
 def test_imports():
     subprocess.run(
-        [sys.executable, "-c", "import scraper;import scraper.cli.scrape_all"],
+        [
+            sys.executable,
+            "-c",
+            "import scraper\nimport scraper.cli.scrape_all",
+        ],
         check=True,
     )


### PR DESCRIPTION
## Summary
- place all test imports at the top of their modules and group them per PEP 8
- replace semicolon-chained commands in smoke test with newline-separated statements
- ensure optional product discovery import gracefully skips when Playwright is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3a525c6108329941b394b74576d3b