### PR TITLE
chore(backend): update CORS dev origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,7 @@ else:
     allow_origins = [
         "http://localhost:3000",
         "http://localhost:38273",
+        "http://localhost:61973",
         "https://smart.bodora.pl",  # → localhost:61973
         "https://backend.bodora.pl",  # → localhost:38273
     ]


### PR DESCRIPTION
## Summary
- include frontend `http://localhost:61973` in backend CORS defaults
## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46753f64883299c3021f24465165c