### PR TITLE
test: set env vars before backend import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ import bcrypt
 from cryptography.fernet import Fernet
 import pytest
 
-from backend import db as backend_db
-
 os.environ.setdefault("SECRET_KEY", "test-secret")
 os.environ.setdefault(
     "ADMIN_PASSWORD_HASH", bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode()
@@ -20,6 +18,7 @@ os.environ.setdefault(
 os.environ["DB_URL"] = ""
 os.environ.setdefault("ALERTS_FERNET_KEY", Fernet.generate_key().decode())
 
+from backend import db as backend_db
 
 @pytest.fixture()
 def migrated_db(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure required env vars are initialized before importing backend db in tests

## Testing
- `pytest tests/test_playwright_headed.py`
- `pytest tests/test_xhr_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2d7c6d7988329bf8485b5255a17ae